### PR TITLE
Replace LocalAlloc/LocalFree with HeapAlloc/HeapFree

### DIFF
--- a/releases/v3.3.195/lib/GameInput.cpp
+++ b/releases/v3.3.195/lib/GameInput.cpp
@@ -74,7 +74,7 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T))));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, capacity * sizeof(T))));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)

--- a/releases/v3.3.195/lib/GameInput.cpp
+++ b/releases/v3.3.195/lib/GameInput.cpp
@@ -63,7 +63,7 @@ public:
     {
         if (m_data != nullptr)
         {
-            LocalFree(m_data);
+            HeapFree(GetProcessHeap(), 0, m_data);
         }
     }
 
@@ -74,13 +74,13 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(LocalAlloc(LPTR, capacity * sizeof(T)));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T))));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)
             {
                 memcpy_s(data, count * sizeof(T), m_data, m_count * sizeof(T));
-                LocalFree(m_data);
+                HeapFree(GetProcessHeap(), 0, m_data);
             }
 
             m_data = data;


### PR DESCRIPTION
Replace Local Allocation functions with the modern Heap functions as suggested in https://learn.microsoft.com/en-us/windows/win32/memory/comparing-memory-allocation-methods

Initially found in SDL codebase they suggested to suggest here as well 
https://github.com/libsdl-org/SDL/pull/16219